### PR TITLE
Split a base image from base dev environment image.

### DIFF
--- a/base-dev-env/Dockerfile
+++ b/base-dev-env/Dockerfile
@@ -1,24 +1,14 @@
-FROM debian:jessie
+FROM latrokles/base-env:latest
 MAINTAINER latrokles@gmail.com
 
-RUN awk '$1 ~ "^deb" { $3 = $3 "-backports"; print; exit  }' \
-    /etc/apt/sources.list > /etc/apt/sources.list.d/backports.list
-
 RUN apt-get update && apt-get install -y \
-    build-essential \
-    git \
-    zsh \
-    curl \
-    tmux \
-    vim
+    build-essential
 
 ENV user latrokles
 ENV HOME /home/${user}
 RUN useradd --create-home --home-dir $HOME ${user} \
         && mkdir -p $HOME/workspace \
         && chown -R ${user}:${user} $HOME
-
-ENV LANG C.UTF-8
 
 RUN chsh ${user} -s /usr/bin/zsh
 WORKDIR $HOME

--- a/base-env/Dockerfile
+++ b/base-env/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian:jessie
+MAINTAINER latrokles@gmail.com
+
+RUN awk '$1 ~ "^deb" { $3 = $3 "-backports"; print; exit  }' \
+    /etc/apt/sources.list > /etc/apt/sources.list.d/backports.list
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    git \
+    tmux \
+    vim \
+    zsh 
+
+ENV LANG C.UTF-8
+CMD ["zsh"]

--- a/base-env/README.md
+++ b/base-env/README.md
@@ -1,0 +1,21 @@
+# README
+
+This is a base docker image from which I plan to build all the others. It
+essentially builds a debian host with a few necessary tools should I ever
+have the need to exec a shell into a container to do some additional 
+troubleshooting. I don't expect these minor tools to use up a lot of space.
+
+## To build:
+```
+docker build -t latrokles/base-env:latest .
+```
+
+## To run:
+There is no real reason to launch a container from this bare image, but just
+in case...
+
+```
+docker run -it \
+        --name base-env \
+        latrokles/base-env:latest \
+```


### PR DESCRIPTION
- Given I want to have images for containers where I may have the need
  to attach a shell into for troubleshooting, but where I don't have a
  need for compilers or other dev toolchains, I have decided to split
  out a base env image that I can extend for either development or
  deployment.
